### PR TITLE
Add try/except to catch non standard residues

### DIFF
--- a/bin/whiscy2bfactor.py
+++ b/bin/whiscy2bfactor.py
@@ -53,12 +53,8 @@ if __name__ == "__main__":
                 if line and line.startswith("ATOM  "):
                     try:
                         res = STANDARD_TYPES[line[17:20].strip()]
-                    except KeyError:
-                        # non standard residue
-                        continue
-                    res_num = line[22:26].strip()
-                    res_id = "{}{}".format(res, res_num)
-                    try:
+                        res_num = line[22:26].strip()
+                        res_id = "{}{}".format(res, res_num)
                         score = scores[res_id]
                         if args.norm:
                             # Normalized Score = 100 * WHISCYSCORE + 50

--- a/bin/whiscy2bfactor.py
+++ b/bin/whiscy2bfactor.py
@@ -51,7 +51,11 @@ if __name__ == "__main__":
             for line in input:
                 line = line.rstrip(os.linesep)
                 if line and line.startswith("ATOM  "):
-                    res = STANDARD_TYPES[line[17:20].strip()]
+                    try:
+                        res = STANDARD_TYPES[line[17:20].strip()]
+                    except KeyError:
+                        # non standard residue
+                        continue
                     res_num = line[22:26].strip()
                     res_id = "{}{}".format(res, res_num)
                     try:


### PR DESCRIPTION
Since non standard residues are not supported in whiscy, I added a small try/except to catch and ignore them in `whiscy2bfactor.py`, should also resolve #6.