### PR TITLE
Add devcontainer configuration file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "whiscy-dev-container",
+  "build": {
+    "dockerfile": "../Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "GitHub.copilot",
+        "ms-python.python",
+        "ms-python.black-formatter"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The installation and configuration of whiscy is a bit tricky, this PR adds a dev-container definition that should facilitate development and debugging