### PR TITLE
replace `SystemExit` with `sys.exit(1)`

### DIFF
--- a/src/whiscy/cli.py
+++ b/src/whiscy/cli.py
@@ -79,7 +79,7 @@ def main():
 
     if not len(converted_surface):
         logger.error("No surface residues")
-        raise SystemExit
+        sys.exit(1)
 
     logger.info("Initializing score calculation...")
     try:
@@ -88,7 +88,7 @@ def main():
         )
     except Exception as err:
         logger.error(str(err))
-        raise SystemExit
+        sys.exit(1)
 
     logger.info("Calculating scores...")
     realsum = 0
@@ -98,7 +98,7 @@ def main():
         totlist.append(r)
         if r.nr > seqlen or r.nr < 1:
             logger.error("Surface residue out of range")
-            raise SystemExit
+            sys.exit(1)
         posnr, distances, scores = pam_calc_similarity(
             converted_surface[n] - 1, seqnr, sequences, seq_distances
         )
@@ -109,7 +109,7 @@ def main():
 
     if realsum == 0:
         logger.error("No sequence information for any surface residues")
-        raise SystemExit
+        sys.exit(1)
 
     logger.info("Subtracting average value ...")
 

--- a/src/whiscy/cli_consadjust.py
+++ b/src/whiscy/cli_consadjust.py
@@ -43,7 +43,7 @@ def main():
 
     if not os.path.exists(args.cons_file):
         logger.error("Conservation file {} does not exist".format(args.cons_file))
-        raise SystemExit
+        sys.exit(1)
 
     logger.info("Reading input files")
 
@@ -65,7 +65,7 @@ def main():
         logger.error(
             "All identical values in conservation file {}".format(args.cons_file)
         )
-        raise SystemExit
+        sys.exit(1)
 
     zcalc = [(res.score - mean) / stddev for res in residues]
 
@@ -73,7 +73,7 @@ def main():
     z_values = np.array(load_z_table(ZTABLE_FILE))
     if len(z_values) != 25000:
         logger.error("Reading error in Z-table {}".format(args.cons_file))
-        raise SystemExit
+        sys.exit(1)
 
     for n in range(consnr):
         pscore = 0.0

--- a/src/whiscy/cli_parasmooth.py
+++ b/src/whiscy/cli_parasmooth.py
@@ -150,7 +150,7 @@ def main():
         res_sur = calculate_parasmooth(res_sur, res_lac, resdist, par)
     except Exception as err:
         logger.error(str(err))
-        raise SystemExit
+        sys.exit(1)
 
     # If output to file
     if args.output_file:

--- a/src/whiscy/cli_setup.py
+++ b/src/whiscy/cli_setup.py
@@ -151,7 +151,7 @@ def main():
                 pdbutil.download_pdb_structure(pdb_code, input_pdb_file)
             except Exception as err:
                 logger.error(str(err))
-                raise SystemExit
+                sys.exit(1)
         else:
             logger.warning(
                 "PDB structure already exists ({0}), no need to download it again".format(
@@ -164,7 +164,7 @@ def main():
 
     if not os.path.exists(input_pdb_file):
         logger.error("PDB structure file {0} not found".format(input_pdb_file))
-        raise SystemExit
+        sys.exit(1)
 
     # Check if chain belongs to this PDB
     pdb_parser = PDBParser(PERMISSIVE=True, QUIET=True)
@@ -173,14 +173,14 @@ def main():
     chain_id = args.chain_id.upper()
     if len(chain_id) > 1:
         logger.error("Wrong chain id {0}".format(chain_id))
-        raise SystemExit
+        sys.exit(1)
     if chain_id not in chain_ids:
         logger.error(
             "Chain {0} provided not in available chains: {1}".format(
                 chain_id, str(chain_ids)
             )
         )
-        raise SystemExit
+        sys.exit(1)
 
     # Save only the given chain and discard residues with alternative positions
     io = PDBIO()
@@ -302,7 +302,7 @@ def main():
 
     if not os.path.exists(phylip_file):
         logger.error("PHYLIP sequence file {0} not found".format(phylip_file))
-        raise SystemExit
+        sys.exit(1)
 
     # Calculate protdist
     protdist_output_file = "{0}_{1}.out".format(filename, chain_id)

--- a/src/whiscy/modules/pdbutil.py
+++ b/src/whiscy/modules/pdbutil.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 
 from Bio import AlignIO
 from Bio.PDB import PDBList
@@ -77,13 +78,15 @@ def map_protein_to_sequence_alignment(
     # Check if sequence is the same
     pdb_seq = "".join([mapping[k] for k in sorted(mapping.keys())])
     if pdb_seq != sequence:
-        raise SystemExit("ERROR: PDB sequence doest not match sequence alignment")
+        print("ERROR: PDB sequence doest not match sequence alignment")
+        sys.exit(1)
 
     # Account for gaps in phylipseq file
     # alignment = list(AlignIO.parse(phylip_file, format='phylip-sequential'))[0]
     # master_phylip = alignment[0].seq
     # if str(master_phylip.ungap('-')) != pdb_seq:
-    #    raise SystemExit("ERROR: PDB sequence doest not match sequence alignment in phylip file")
+    #    print("ERROR: PDB sequence doest not match sequence alignment in phylip file")
+    #    sys.exit(1)
 
     with open(output_file_name, "w") as output_handle:
         output_handle.write(


### PR DESCRIPTION
This PR replaces the `raise SystemExit` statement with `sys.exit(1)`.

This is needed because the exit status of `SystemExit` is 0;

```bash
$ python -c "raise SystemExit"
$ echo $?
0

$ python -c "import sys; sys.exit(1)"
$ echo $?
1
```

fix #32 
fix #31 
fix #30 
fix #29 